### PR TITLE
Add position to player data, add position checkboxes to form

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,29 @@
             <hr>
             
             <form>
+                <div class="form-group" id="position-select">
+                    <label>Positions:</label><br>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="checkbox" id="position-select-pg" value="PG">
+                        <label class="form-check-label" for="position-select-pg">Point Guard</label>
+                    </div>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="checkbox" id="position-select-sg" value="SG">
+                        <label class="form-check-label" for="position-select-sg">Shooting Guard</label>
+                    </div>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="checkbox" id="position-select-sf" value="SF">
+                        <label class="form-check-label" for="position-select-sf">Small Forward</label>
+                    </div>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="checkbox" id="position-select-pf" value="PF">
+                        <label class="form-check-label" for="position-select-pf">Power Forward</label>
+                    </div>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="checkbox" id="position-select-c" value="C">
+                        <label class="form-check-label" for="position-select-c">Center</label>
+                    </div>
+                </div>
                 <div class="form-group">
                     <label for="defense-slider">Defense:</label>
                     <input type="range" min="0" max="100" class="form-control-range" id="defense-slider" value="10">
@@ -78,11 +101,11 @@
             </div>
         </div>
     </div>
-    <script src="scripts.js"></script>
-    <script src="players.js"></script>
     <!-- JS, Popper.js, and jQuery -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.js" integrity="sha256-QWo7LDvxbWT2tbbQ97B53yJnYU3WhH/C8ycbRAkjPDc=" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous"></script>  
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous"></script>
+    <script src="scripts.js"></script>
+    <script src="players_with_position.json"></script>
 </body>
 </html>

--- a/players_with_position.json
+++ b/players_with_position.json
@@ -1,0 +1,4072 @@
+[
+  {
+    "tier": 1,
+    "players": [
+      {
+        "Player": "LeBron James",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "CJ McCollum",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Devin Booker",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "James Harden",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Damian Lillard",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Bam Adebayo",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Donovan Mitchell",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Nikola Jokić",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Rudy Gobert",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "DeMar DeRozan",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Jayson Tatum",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Chris Paul",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Anthony Davis",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Trae Young",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Jrue Holiday",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Pascal Siakam",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Ja Morant",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "OG Anunoby",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Bradley Beal",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Luka Dončić",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Ben Simmons",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Jamal Murray",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Carmelo Anthony",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Giannis Antetokounmpo",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Kawhi Leonard",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Kristaps Porziņģis",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Kevin Love",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "LaMarcus Aldridge",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Russell Westbrook",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Joel Embiid",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "D'Angelo Russell",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Paul George",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Mike Conley",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Dwight Howard",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Derrick Rose",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Draymond Green",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Karl-Anthony Towns",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Marc Gasol",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Kyrie Irving",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Vince Carter",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Zion Williamson",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Brandon Ingram",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Blake Griffin",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Klay Thompson",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Steph Curry",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      }
+    ]
+  },
+  {
+    "tier": 2,
+    "players": [
+      {
+        "Player": "Harrison Barnes",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Tobias Harris",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "P.J. Tucker",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Shai Gilgeous-Alexander",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Buddy Hield",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Devonte' Graham",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "T.J. Warren",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Duncan Robinson",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Terry Rozier",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Domantas Sabonis",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Collin Sexton",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Robert Covington",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF-C"
+      },
+      {
+        "Player": "Ersan İlyasova",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Joe Harris",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Dorian Finney-Smith",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Dillon Brooks",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Joe Ingles",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Kyle Lowry",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Tim Hardaway Jr.",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Zach LaVine",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Bojan Bogdanović",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Julius Randle",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Evan Fournier",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Royce O'Neale",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Mikal Bridges",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Lonzo Ball",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Al Horford",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "De'Andre Hunter",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Aaron Gordon",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Ricky Rubio",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Nemanja Bjelica",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Hassan Whiteside",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Dennis Schröder",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Nikola Vučević",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Markelle Fultz",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Miles Bridges",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Spencer Dinwiddie",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Kendrick Nunn",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Jimmy Butler",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Marcus Morris",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SF-PF"
+      },
+      {
+        "Player": "Jaylen Brown",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Kelly Oubre Jr.",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Fred VanVleet",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Marcus Smart",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Will Barton",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Danuel House",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Cedi Osman",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Jerami Grant",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Maxi Kleber",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Terrence Ross",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Andre Drummond",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Tomáš Satoranský",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Jae Crowder",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Lou Williams",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Andrew Wiggins",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SF-SG"
+      },
+      {
+        "Player": "Taurean Prince",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Khris Middleton",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Jarrett Allen",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Jonas Valančiūnas",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Danilo Gallinari",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Justin Holiday",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Myles Turner",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Darius Garland",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Brook Lopez",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Ish Smith",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Glenn Robinson III",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Troy Brown Jr.",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Gary Harris",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Bogdan Bogdanović",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Kentavious Caldwell-Pope",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Kevin Huerter",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Cory Joseph",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "P.J. Washington",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Josh Hart",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Alec Burks",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Montrezl Harrell",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Kemba Walker",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Gordon Hayward",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Garrett Temple",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Tristan Thompson",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Jordan Clarkson",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "RJ Barrett",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Langston Galloway",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Josh Richardson",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Kent Bazemore",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF-SG"
+      },
+      {
+        "Player": "Danny Green",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Dejounte Murray",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Steven Adams",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Derrick White",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Coby White",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Malcolm Brogdon",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Goran Dragić",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Eric Paschall",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Eric Bledsoe",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Tony Snell",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Monte Morris",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Wesley Matthews",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Bruce Brown",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "De'Aaron Fox",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Dario Šarić",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Jaren Jackson Jr.",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Ben McLemore",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Aaron Holiday",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Austin Rivers",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Thaddeus Young",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Dāvis Bertāns",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "J.J. Redick",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Bryn Forbes",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Seth Curry",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Delon Wright",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Daniel Theis",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Furkan Korkmaz",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Cam Reddish",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Josh Okogie",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Kyle Kuzma",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Donte DiVincenzo",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Tyler Herro",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Jarrett Culver",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Trevor Ariza",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Lauri Markkanen",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Serge Ibaka",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Patty Mills",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Norman Powell",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Larry Nance Jr.",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Jeff Teague",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Rudy Gay",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Landry Shamet",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Anfernee Simons",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Rui Hachimura",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Maurice Harkless",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Damion Lee",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "D.J. Augustin",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Mitchell Robinson",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Bobby Portis",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Derrick Jones Jr.",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Doug McDermott",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Brad Wanamaker",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "John Collins",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Shabazz Napier",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Patrick Beverley",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Cody Zeller",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Gary Trent Jr.",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Kyle Anderson",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Caris LeVert",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "T.J. McConnell",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Ivica Zubac",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Christian Wood",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "JaMychal Green",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Brandon Clarke",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Kelly Olynyk",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Jeremy Lamb",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Matisse Thybulle",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Clint Capela",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Jordan Poole",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "George Hill",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Trey Lyles",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Kris Dunn",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "James Ennis",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Sviatoslav Mykhailiuk",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Terrance Ferguson",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Wendell Carter Jr.",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Cameron Johnson",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Isaac Bonga",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Elfrid Payton",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Pat Connaughton",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Derrick Favors",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Richaun Holmes",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Paul Millsap",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Deandre Ayton",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "DeAndre Jordan",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Tyus Jones",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Malik Beasley",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Terence Davis",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Mike Scott",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Marquese Chriss",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Markieff Morris",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Frank Ntilikina",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Avery Bradley",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Alex Caruso",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Jakob Poeltl",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Malik Monk",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "De'Anthony Melton",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Kevin Knox",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Kevin Porter Jr.",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Thomas Bryant",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Darius Bazley",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "JaVale McGee",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Marvin Williams",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Nerlens Noel",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Rondae Hollis-Jefferson",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Willie Cauley-Stein",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Gorgui Dieng",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Solomon Hill",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Jaxson Hayes",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Torrey Craig",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Dwight Powell",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Mason Plumlee",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Justin Jackson",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Grant Williams",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Nicolò Melli",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Meyers Leonard",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Bismack Biyombo",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Taj Gibson",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Jalen Brunson",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "E'Twaun Moore",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Eric Gordon",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Ky Bowman",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Semi Ojeleye",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Lonnie Walker",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Wesley Iwundu",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Rajon Rondo",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Enes Kanter",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Jerome Robinson",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Alex Len",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Jeff Green",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF-C"
+      },
+      {
+        "Player": "Kyle Korver",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Robin Lopez",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Jonathan Isaac",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Jevon Carter",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Aron Baynes",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Ryan Arcidiacono",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Treveon Graham",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Isaiah Thomas",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Georges Niang",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Khem Birch",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Luke Kennard",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Jabari Parker",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "DeAndre' Bembry",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Patrick McCaw",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Cody Martin",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Michael Porter Jr.",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Hamidou Diallo",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Damian Jones",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Omari Spellman",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Marco Belinelli",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Mo Bamba",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Anthony Tolliver",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Mario Hezonja",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Rodney McGruder",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Abdel Nader",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Timothé Luwawu-Cabarrot",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Emmanuel Mudiay",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Damyean Dotson",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Moritz Wagner",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Michael Carter-Williams",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Juan Hernangómez",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Kenrich Williams",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Matthew Dellavedova",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Luguentz Dort",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Chris Boucher",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Ian Mahinmi",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Shake Milton",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Frank Jackson",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Jordan McRae",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Frank Kaminsky",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Thon Maker",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Patrick Patterson",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Dewayne Dedmon",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Sterling Brown",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Sekou Doumbouya",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Keita Bates-Diop",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Reggie Jackson",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Wilson Chandler",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Elie Okobo",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Grayson Allen",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Bruno Fernando",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Tyler Johnson",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Dwayne Bacon",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Reggie Bullock",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Rodions Kurucs",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Raul Neto",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Harry Giles",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Tony Bradley",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Allen Crabbe",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Rodney Hood",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "James Johnson",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Daniel Gafford",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "John Henson",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Alfonzo McKinnie",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Nickeil Alexander-Walker",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Jordan McLaughlin",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Nassir Little",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Mike Muscala",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Gary Clark",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Skal Labissière",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Luke Kornet",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Wayne Ellington",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Dennis Smith Jr.",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Troy Daniels",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Yogi Ferrell",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Victor Oladipo",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Chandler Hutchison",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Trey Burke",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Quinn Cook",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Nicolas Batum",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Jake Layman",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Kelan Martin",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Naz Reid",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Denzel Valentine",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Džanan Musa",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Dante Exum",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Marko Guduric",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Shaquille Harrison",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Cheick Diallo",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Goga Bitadze",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Javonte Green",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Jahlil Okafor",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Brandon Knight",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "J.J. Barea",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Edmond Sumner",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Matt Thomas",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Anžejs Pasečņiks",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Thabo Sefolosha",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Gary Payton II",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Brandon Goodwin",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Boban Marjanović",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Jacob Evans",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Andre Iguodala",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "PJ Dozier",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Chris Chiozza",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Robert Williams",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Cristiano Felício",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Josh Jackson",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Al-Farouq Aminu",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Noah Vonleh",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C-PF"
+      },
+      {
+        "Player": "Willy Hernangómez",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Romeo Langford",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Admiral Schofield",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Theo Pinson",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Jared Dudley",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "D.J. Wilson",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Terance Mann",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Deonte Burton",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Tim Frazier",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Justise Winslow",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Carsen Edwards",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Chris Silva",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Courtney Lee",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Marvin Bagley III",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": true,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Otto Porter",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Ty Jerome",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      },
+      {
+        "Player": "Caleb Martin",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Kyle O'Quinn",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Ed Davis",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Keldon Johnson",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": true,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Jalen McDaniels",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Chris Clemons",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "SG"
+      },
+      {
+        "Player": "Allonzo Trier",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": false,
+        "passing": true,
+        "scoring": true,
+        "Pos": "PG"
+      },
+      {
+        "Player": "DeMarre Carroll",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SF-PF"
+      },
+      {
+        "Player": "Zach Collins",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Caleb Swanigan",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Dragan Bender",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Michael Kidd-Gilchrist",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF-PF"
+      },
+      {
+        "Player": "Drew Eubanks",
+        "shooting": true,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "PF"
+      },
+      {
+        "Player": "Juan Toscano-Anderson",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "David Nwaba",
+        "shooting": true,
+        "rebounding": false,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "SF"
+      },
+      {
+        "Player": "Isaiah Hartenstein",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": true,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Kevon Looney",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C"
+      },
+      {
+        "Player": "Jordan Bell",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": false,
+        "defense": false,
+        "passing": false,
+        "scoring": false,
+        "Pos": "C-PF"
+      },
+      {
+        "Player": "Jusuf Nurkić",
+        "shooting": false,
+        "rebounding": true,
+        "ballhandling": true,
+        "defense": true,
+        "passing": true,
+        "scoring": true,
+        "Pos": "C"
+      },
+      {
+        "Player": "Evan Turner",
+        "shooting": false,
+        "rebounding": false,
+        "ballhandling": true,
+        "defense": false,
+        "passing": true,
+        "scoring": false,
+        "Pos": "PG"
+      }
+    ]
+  }
+]

--- a/scripts.js
+++ b/scripts.js
@@ -117,6 +117,27 @@ function goBack () {
   weaknesses.innerText = "None."
 }
 
+var json;
+$.getJSON("players_with_position.json", function(data) {
+  json = data;
+});
+
+function findComps(profile, tier) {
+  players = json.find(a => a["tier"] == tier)["players"]
+  return players.filter(function(v, i) {
+    positionMatch = comparePositions(v.Pos, profile.positions);
+    return (positionMatch && v.shooting == profile.shooting && v.ballhandling == profile.ballhandling && v.defense == profile.defense && v.passing == profile.passing && v.rebounding == profile.rebounding && v.scoring == profile.scoring)
+  })
+}
+
+function comparePositions(playerPosition, positionList) {
+  if (positionList.length > 0) {
+    return (new RegExp(positionList.join("|")).test(playerPosition));
+  } else {
+    return true;
+  }
+}
+
 //hide the slider bars and bring up the scouting report page
 function fillProfile () {
   //fill strengths and weaknesses arrays by descriptions
@@ -140,8 +161,8 @@ function fillProfile () {
 
   document.getElementById("banner").innerText = "DRAFT PROFILE: " + document.getElementById("name").value.toUpperCase()
   setProfile()
-  document.getElementById("high-comps").innerText = (findHighComps(myProfile).length > 0) ? findHighComps(myProfile).map(a => a.Player).join(", ") : "No matching comps."
-  document.getElementById("low-comps").innerText = (findLowComps(myProfile).length > 0) ? findLowComps(myProfile).map(a => a.Player).join(", ") : "No matching comps."
+  document.getElementById("high-comps").innerText = (findComps(myProfile, 1).length > 0) ? findComps(myProfile, 1).map(a => a.Player).join(", ") : "No matching comps."
+  document.getElementById("low-comps").innerText = (findComps(myProfile, 2).length > 0) ? findComps(myProfile, 2).map(a => a.Player).join(", ") : "No matching comps."
   document.getElementById("pick-range").innerText = pickRange()
   
 }
@@ -188,6 +209,18 @@ let myProfile = {
   myProfile.defense = (document.getElementById("defense-slider").value > 50)
   myProfile.rebounding = (document.getElementById("rebounding-slider").value > 50)
   myProfile.scoring = (document.getElementById("scoring-slider").value > 50)
+  myProfile.positions = getPositions()
+}
+
+function getPositions() {
+  $selectedPositions = $("#position-select").find("input:checked");
+  if ($selectedPositions.length > 0) {
+    return $selectedPositions.map(function(idx, element) {
+      return $(element).val();
+    }).get();
+  } else {
+    return [];
+  }
 }
 
 


### PR DESCRIPTION
![lazy_player_comp_pr](https://user-images.githubusercontent.com/7432170/93719784-693d5400-fb4a-11ea-9508-aa22dffee192.PNG)

- Adds `players_with_position.json`, which is basically the data from `players.js` with position data from `complete_player_data.js`
- `scripts.js` now reads data from `players_with_position.json`, so references to `players.js` have been removed. `players.js` also can be removed entirely
- Adds position checkboxes to form
- `findHighComps` and `findLowComps` refactored into one function
